### PR TITLE
Windows shell phase 1

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -300,6 +300,9 @@ users)
 
 ## Shell
   * fish: fix deprecated redirection syntax `^` [#4736 @vzaliva]
+  * dash: recognize dash as a POSIX shell for opam env [#4816 @jonahbeckford]
+  * pwsh,powershell: use $env: for opam env [#4816 @jonahbeckford]
+  * command prompt: use SET for opam env [#4816 @jonahbeckford]
 
 ## Doc
   * Standardise `macOS` use [#4782 @kit-ty-kate]

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1031,6 +1031,9 @@ let shell_opt cli validity =
     "csh",SH_csh;
     "zsh",SH_zsh;
     "fish",SH_fish;
+    "pwsh",SH_pwsh;
+    "cmd",SH_win_cmd;
+    "powershell",SH_win_powershell
   ] |> List.map (fun (s,v) -> cli_original, s, v)
   in
   mk_enum_opt ~cli validity ["shell"] "SHELL" enum

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1224,7 +1224,10 @@ let config cli =
        | Some sw ->
          `Ok (OpamConfigCommand.env gt sw
                 ~set_opamroot ~set_opamswitch
-                ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish) ~inplace_path))
+                ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
+                ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
+                ~cmd:(shell=SH_win_cmd)
+                ~inplace_path))
     | Some `revert_env, [] ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
       (match OpamStateConfig.get_switch_opt () with
@@ -1233,6 +1236,8 @@ let config cli =
          `Ok (OpamConfigCommand.ensure_env gt sw;
               OpamConfigCommand.print_eval_env
                 ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
+                ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
+                ~cmd:(shell=SH_win_cmd)
                 (OpamEnv.add [] [])))
     | Some `list, [] ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
@@ -1529,10 +1534,15 @@ let env cli =
        | Some sw ->
          OpamConfigCommand.env gt sw
            ~set_opamroot ~set_opamswitch
-           ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish) ~inplace_path);
+           ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
+           ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
+           ~cmd:(shell=SH_win_cmd)
+           ~inplace_path);
     | true ->
       OpamConfigCommand.print_eval_env
         ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
+        ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
+        ~cmd:(shell=SH_win_cmd)
         (OpamEnv.add [] [])
   in
   let open Common_config_flags in

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -105,9 +105,16 @@ let print_cmd_env env =
       if OpamConsole.verbose () then
         OpamStd.Option.iter (OpamConsole.msg ": %s;\n") comment;
       if not (List.exists (fun (k1, _, _) -> k = k1) r) || OpamConsole.verbose ()
-      then
-        OpamConsole.msg "SET %s=%s\n"
-          k (OpamStd.Env.escape_windows_command_line v);
+      then begin
+        let is_special = function
+        | '(' | ')' | '!' | '^' | '%' | '"' | '<' | '>' | '|' -> true
+        | _ -> false
+        in
+        if OpamCompat.String.(exists is_special v || exists is_special k) then
+          OpamConsole.msg "SET \"%s=%s\"\n" k v
+        else
+          OpamConsole.msg "SET %s=%s\n" k v
+      end;
       aux r
   in
   aux env

--- a/src/client/opamConfigCommand.mli
+++ b/src/client/opamConfigCommand.mli
@@ -23,8 +23,8 @@ open OpamStateTypes
 val env:
   'a global_state -> switch ->
   ?set_opamroot:bool -> ?set_opamswitch:bool ->
-  csh:bool -> sexp:bool -> fish:bool -> inplace_path:bool ->
-  unit
+  csh:bool -> sexp:bool -> fish:bool -> pwsh:bool -> cmd:bool ->
+  inplace_path:bool -> unit
 
 (** Ensures that the environment file exists in the given switch, regenerating
     it, if necessary. *)
@@ -32,7 +32,7 @@ val ensure_env: 'a global_state -> switch -> unit
 
 (** Like [env] but allows one to specify the precise env to print rather than
     compute it from a switch state *)
-val print_eval_env: csh:bool -> sexp:bool -> fish:bool -> env -> unit
+val print_eval_env: csh:bool -> sexp:bool -> fish:bool -> pwsh:bool -> cmd:bool -> env -> unit
 
 (** Display the content of all available packages variables *)
 val list: 'a switch_state -> name list -> unit

--- a/src/core/opamCompat.ml
+++ b/src/core/opamCompat.ml
@@ -8,7 +8,22 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module String = String
+module String =
+#if OCAML_VERSION >= (4, 13, 0)
+  String
+#else
+struct
+  include String
+
+  let exists p s =
+    let n = length s in
+    let rec loop i =
+      if i = n then false
+      else if p (unsafe_get s i) then true
+      else loop (succ i) in
+    loop 0
+end
+#endif
 
 module Char = Char
 

--- a/src/core/opamCompat.mli
+++ b/src/core/opamCompat.mli
@@ -8,7 +8,17 @@
 (*                                                                        *)
 (**************************************************************************)
 
-module String = String
+module String
+#if OCAML_VERSION >= (4, 13, 0)
+= String
+#else
+: sig
+  include module type of struct include String end
+
+  val exists: (char -> bool) -> string -> bool
+end
+#endif
+
 
 module Char = Char
 

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -923,6 +923,7 @@ module OpamSys = struct
     | "bash" -> Some SH_bash
     | "fish" -> Some SH_fish
     | "pwsh" -> Some SH_pwsh
+    | "dash"
     | "sh"   -> Some SH_sh
     | _      -> None
 

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -733,12 +733,6 @@ module Env = struct
     (* escape single quotes with two single quotes.
        https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.1 *)
     Re.(replace_string (compile (char '\'')) ~by:"''")
-
-  let escape_windows_command_line s =
-    (* escape all Windows command line metacharacters with a caret (^) *)
-    List.fold_left
-      (fun acc ch -> Re.(replace_string (compile (char ch)) ~by:("^" ^ String.make 1 ch) acc))
-      s ['^'; '"'; '&'; '|'; '<'; '>']
 end
 
 

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -912,7 +912,7 @@ module OpamSys = struct
   type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_pwsh
     | SH_win_cmd | SH_win_powershell
 
-  let windows_default_shell = SH_win_powershell
+  let windows_default_shell = SH_win_cmd
   let unix_default_shell = SH_sh
 
   let shell_of_string = function

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -984,7 +984,9 @@ module OpamSys = struct
     lazy (
       let ancestors = Lazy.force (windows_ancestor_process_names ()) in
       match (List.map String.lowercase_ascii ancestors |>
-              List.filter_map categorize_process) with
+              List.map categorize_process |>
+              List.filter (function Some _ -> true | None -> false) |>
+              List.map (function Some v -> v | None -> assert false)) with
       | [] -> None
       | Reject :: _ -> None
       | Accept most_relevant_shell :: _ -> Some most_relevant_shell

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -728,6 +728,17 @@ module Env = struct
       Re.(replace (compile (set "\\\'")) ~f:(fun g -> "\\"^Group.get g 0))
     else
       Re.(replace_string (compile (char '\'')) ~by:"'\"'\"'")
+
+  let escape_powershell =
+    (* escape single quotes with two single quotes.
+       https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-7.1 *)
+    Re.(replace_string (compile (char '\'')) ~by:"''")
+
+  let escape_windows_command_line s =
+    (* escape all Windows command line metacharacters with a caret (^) *)
+    List.fold_left
+      (fun acc ch -> Re.(replace_string (compile (char ch)) ~by:("^" ^ String.make 1 ch) acc))
+      s ['^'; '"'; '&'; '|'; '<'; '>']
 end
 
 
@@ -898,7 +909,11 @@ module OpamSys = struct
     ) in
     fun () -> Lazy.force os
 
-  type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish
+  type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_pwsh
+    | SH_win_cmd | SH_win_powershell
+
+  let windows_default_shell = SH_win_powershell
+  let unix_default_shell = SH_sh
 
   let shell_of_string = function
     | "tcsh"
@@ -907,6 +922,7 @@ module OpamSys = struct
     | "zsh"  -> Some SH_zsh
     | "bash" -> Some SH_bash
     | "fish" -> Some SH_fish
+    | "pwsh" -> Some SH_pwsh
     | "sh"   -> Some SH_sh
     | _      -> None
 
@@ -920,50 +936,117 @@ module OpamSys = struct
     else
       fun x -> x
 
-  let guess_shell_compat () =
-    let parent_guess =
-      if Sys.win32 then
-        None
+  let windows_max_ancestor_depth = 5
+
+  (** [windows_ancestor_process_names] finds the names of the parent of the
+      current process and all of its ancestors up to [max_ancestor_depth]
+      in length.
+
+      The immediate parent of the current process will be first in the list.
+    *)
+  let windows_ancestor_process_names () =
+    let rec helper pid depth =
+      if depth > windows_max_ancestor_depth then []
       else
-        let ppid = Unix.getppid () in
-        let dir = Filename.concat "/proc" (string_of_int ppid) in
+      try
+        OpamStubs.(getProcessName pid ::
+                   helper
+                     (getParentProcessID pid)
+                     (depth + 1))
+      with Failure _ -> []
+    in
+    lazy (
+      try
+        let parent = OpamStubs.getCurrentProcessID () in
+        helper (OpamStubs.getParentProcessID parent) 0
+      with Failure _ -> []
+    )
+
+  type shell_choice = Reject | Accept of shell
+
+  let windows_get_shell =
+    let categorize_process = function
+      | "powershell.exe" | "powershell_ise.exe" -> Some (Accept SH_win_powershell)
+      | "pwsh.exe" -> Some (Accept SH_pwsh)
+      | "cmd.exe" -> Some (Accept SH_win_cmd)
+      | "env.exe" ->
+        (* If the nearest ancestor is env.exe it may be `env bash` or
+           even `env cmd.exe`. On Windows we can't see whether bash,
+           cmd or something else was chosen by `env ...`. So kick
+           out of categorization immediately. *)
+        Some Reject
+      | name ->
+        Option.map
+          (fun shell -> Accept shell)
+          (shell_of_string (Filename.chop_suffix name ".exe"))
+    in
+    lazy (
+      let ancestors = Lazy.force (windows_ancestor_process_names ()) in
+      match (List.map String.lowercase_ascii ancestors |>
+              List.filter_map categorize_process) with
+      | [] -> None
+      | Reject :: _ -> None
+      | Accept most_relevant_shell :: _ -> Some most_relevant_shell
+    )
+
+  let guess_shell_compat () =
+    let parent_guess () =
+      let ppid = Unix.getppid () in
+      let dir = Filename.concat "/proc" (string_of_int ppid) in
+      try
+        Some (Unix.readlink (Filename.concat dir "exe"))
+      with e ->
+        fatal e;
         try
-          Some (Unix.readlink (Filename.concat dir "exe"))
-        with e ->
-          fatal e;
-          try
-            with_process_in "ps"
-              (Printf.sprintf "-p %d -o comm= 2>/dev/null" ppid)
-              (fun ic -> Some (input_line ic))
-          with
-          | Unix.Unix_error _ | Sys_error _ | Failure _ | End_of_file | Not_found ->
-              try
-                let c = open_in_bin ("/proc/" ^ string_of_int ppid ^ "/cmdline") in
-                begin try
-                  let s = input_line c in
+          with_process_in "ps"
+            (Printf.sprintf "-p %d -o comm= 2>/dev/null" ppid)
+            (fun ic -> Some (input_line ic))
+        with
+        | Unix.Unix_error _ | Sys_error _ | Failure _ | End_of_file | Not_found ->
+            try
+              let c = open_in_bin ("/proc/" ^ string_of_int ppid ^ "/cmdline") in
+              begin try
+                let s = input_line c in
+                close_in c;
+                Some (String.sub s 0 (String.index s '\000'))
+              with
+              | Not_found ->
+                  None
+              | e ->
                   close_in c;
-                  Some (String.sub s 0 (String.index s '\000'))
-                with
-                | Not_found ->
-                    None
-                | e ->
-                    close_in c;
-                    fatal e; None
-                end
-              with e ->
-                fatal e; None
+                  fatal e; None
+              end
+            with e ->
+              fatal e; None
     in
     let test shell = shell_of_string (Filename.basename shell) in
-    let shell =
-      match Option.replace test parent_guess with
-      | None ->
+    if Sys.win32 then
+      let shell =
+        match Lazy.force windows_get_shell with
+        | None ->
           Option.of_Not_found Env.get "SHELL" |> Option.replace test
-      | some ->
+        | some ->
           some
-    in
-    Option.default SH_sh shell
+        in
+      Option.default windows_default_shell shell
+    else
+      let shell =
+        match Option.replace test (parent_guess ()) with
+        | None ->
+            Option.of_Not_found Env.get "SHELL" |> Option.replace test
+        | some ->
+            some
+      in
+      Option.default unix_default_shell shell
 
   let guess_dot_profile shell =
+    let win_my_powershell f =
+      let p = Filename.concat (home ()) "Documents" in
+      if Sys.file_exists p then Filename.concat (Filename.concat p "PowerShell") f
+      else let p = Filename.concat (home ()) "My Documents" in
+      if Sys.file_exists p then Filename.concat (Filename.concat p "PowerShell") f
+      else f
+    in
     let home f =
       try Filename.concat (home ()) f
       with Not_found -> f in
@@ -992,7 +1075,13 @@ module OpamSys = struct
       let cshrc = home ".cshrc" in
       let tcshrc = home ".tcshrc" in
       if Sys.file_exists cshrc then cshrc else tcshrc
+    | SH_pwsh | SH_win_powershell ->
+      if Sys.win32 then win_my_powershell "Microsoft.Powershell_profile.ps1" else
+      List.fold_left Filename.concat (home ".config") ["powershell"; "Microsoft.Powershell_profile.ps1"]
     | SH_sh -> home ".profile"
+    | SH_win_cmd ->
+      (* cmd.exe does not have a concept of profiles *)
+      home ".profile"
 
 
   let registered_at_exit = ref []

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -389,6 +389,12 @@ module Env : sig
       [using_backslashes] to escape both quotes and backslashes using
       backslashes *)
   val escape_single_quotes: ?using_backslashes:bool -> string -> string
+
+  (** Utility function for PowerShell strings. *)
+  val escape_powershell: string -> string
+
+  (** Utility function for Windows command line (cmd.exe) strings. *)
+  val escape_windows_command_line: string -> string
 end
 
 (** {2 System query and exit handling} *)
@@ -436,7 +442,8 @@ module Sys : sig
   val executable_name : string -> string
 
   (** The different families of shells we know about *)
-  type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish
+  type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_pwsh
+    | SH_win_cmd | SH_win_powershell
 
   (** Guess the shell compat-mode *)
   val guess_shell_compat: unit -> shell

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -392,9 +392,6 @@ module Env : sig
 
   (** Utility function for PowerShell strings. *)
   val escape_powershell: string -> string
-
-  (** Utility function for Windows command line (cmd.exe) strings. *)
-  val escape_windows_command_line: string -> string
 end
 
 (** {2 System query and exit handling} *)

--- a/src/core/opamStubs.dummy.ml
+++ b/src/core/opamStubs.dummy.ml
@@ -34,5 +34,6 @@ let process_putenv _ = that's_a_no_no
 let shGetFolderPath _ = that's_a_no_no
 let sendMessageTimeout _ _ _ _ _ = that's_a_no_no
 let getParentProcessID = that's_a_no_no
+let getProcessName = that's_a_no_no
 let getConsoleAlias _ = that's_a_no_no
 let win_create_process _ _ _ _ _ = that's_a_no_no

--- a/src/core/opamStubs.mli
+++ b/src/core/opamStubs.mli
@@ -69,7 +69,7 @@ val writeRegistry :
   (** Windows only. [writeRegistry root key name value_type value] sets the
       value [name] of type [value_type] in registry key [key] of [root] to
       [value].
- 
+
       @raise Failure If the value could not be set.
       @raise Not_found If [key] does not exist. *)
 
@@ -123,6 +123,11 @@ val getParentProcessID : int32 -> int32
     of [pid].
 
     @raise Failure If walking the process tree fails to find the process. *)
+
+val getProcessName : int32 -> string
+(** Windows only. [getProcessName pid] returns the executable name of [pid].
+
+    @raise Failure If the process does not exist. *)
 
 val getConsoleAlias : string -> string -> string
 (** Windows only. [getConsoleAlias alias exeName] retrieves the value for a

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -317,7 +317,8 @@ type pin_kind = [ `version | OpamUrl.backend ]
 
 (** Shell compatibility modes *)
 type shell = OpamStd.Sys.shell =
-    SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish
+    SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_pwsh
+    | SH_win_cmd | SH_win_powershell
 
 (** {2 Generic command-line definitions with filters} *)
 

--- a/src/format/opamTypesBase.ml
+++ b/src/format/opamTypesBase.ml
@@ -48,6 +48,9 @@ let string_of_shell = function
   | SH_zsh  -> "zsh"
   | SH_sh   -> "sh"
   | SH_bash -> "bash"
+  | SH_pwsh -> "pwsh"
+  | SH_win_cmd -> "cmd"
+  | SH_win_powershell -> "powershell"
 
 let file_null = ""
 let pos_file filename =

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -365,10 +365,14 @@ let is_up_to_date ?skip st =
 (** Returns shell-appropriate statement to evaluate [cmd]. *)
 let shell_eval_invocation shell cmd =
   match shell with
+  | SH_win_powershell | SH_pwsh ->
+    Printf.sprintf "(& %s) -split '\\r?\\n' | ForEach-Object { Invoke-Expression $_ }" cmd
   | SH_fish ->
     Printf.sprintf "eval (%s)" cmd
   | SH_csh ->
     Printf.sprintf "eval `%s`" cmd
+  | SH_win_cmd ->
+    Printf.sprintf {|for /f "tokens=*" %%i in ('%s') do @%%i|} cmd
   | _ ->
     Printf.sprintf "eval $(%s)" cmd
 
@@ -423,35 +427,43 @@ let shells_list = [ SH_sh; SH_zsh; SH_csh; SH_fish ]
 let complete_file = function
   | SH_sh | SH_bash -> Some "complete.sh"
   | SH_zsh -> Some "complete.zsh"
-  | SH_csh | SH_fish -> None
+  | SH_csh | SH_fish | SH_pwsh | SH_win_cmd | SH_win_powershell -> None
 
 let env_hook_file = function
   | SH_sh | SH_bash -> Some "env_hook.sh"
   | SH_zsh -> Some "env_hook.zsh"
   | SH_csh -> Some "env_hook.csh"
   | SH_fish -> Some "env_hook.fish"
+  | SH_pwsh | SH_win_cmd | SH_win_powershell ->
+    (* N/A because not present in `shells_list` yet *) None
 
 let variables_file = function
   | SH_sh | SH_bash | SH_zsh -> "variables.sh"
   | SH_csh -> "variables.csh"
   | SH_fish -> "variables.fish"
+  | SH_pwsh | SH_win_cmd | SH_win_powershell ->
+    (* N/A because not present in `shells_list` yet *) "variables.sh"
 
 let init_file = function
   | SH_sh | SH_bash -> "init.sh"
   | SH_zsh -> "init.zsh"
   | SH_csh -> "init.csh"
   | SH_fish -> "init.fish"
+  | SH_pwsh | SH_win_cmd | SH_win_powershell ->
+    (* N/A because not present in `shells_list` yet *) "init.sh"
 
 let complete_script = function
   | SH_sh | SH_bash -> Some OpamScript.complete
   | SH_zsh -> Some OpamScript.complete_zsh
   | SH_csh | SH_fish -> None
+  | SH_pwsh | SH_win_cmd | SH_win_powershell -> None
 
 let env_hook_script_base = function
   | SH_sh | SH_bash -> Some OpamScript.env_hook
   | SH_zsh -> Some OpamScript.env_hook_zsh
   | SH_csh -> Some OpamScript.env_hook_csh
   | SH_fish -> Some OpamScript.env_hook_fish
+  | SH_pwsh | SH_win_cmd | SH_win_powershell -> None
 
 let export_in_shell shell =
   let make_comment comment_opt =
@@ -487,10 +499,21 @@ let export_in_shell shell =
       Printf.sprintf "%sset -gx %s %s;\n"
         (make_comment comment) k v
   in
+  let pwsh (k,v,comment) =
+    Printf.sprintf "%s$env:%s=%s;\n"
+      (make_comment comment) k v in
+  let win_cmd (k,v,comment) =
+    let make_cmd_comment comment_opt =
+      OpamStd.Option.to_string (Printf.sprintf "REM %s\n") comment_opt
+    in
+    Printf.sprintf "%sSET \"%s=%s\"\n"
+      (make_cmd_comment comment) k v in
   match shell with
   | SH_zsh | SH_bash | SH_sh -> sh
   | SH_fish -> fish
   | SH_csh -> csh
+  | SH_pwsh | SH_win_powershell -> pwsh
+  | SH_win_cmd -> win_cmd
 
 let env_hook_script shell =
   OpamStd.Option.map (fun script ->
@@ -511,11 +534,23 @@ let source root shell f =
   | SH_zsh ->
     Printf.sprintf "[[ ! -r %s ]] || source %s  > /dev/null 2> /dev/null\n"
       fname fname
+  | SH_win_cmd ->
+    Printf.sprintf "if exist \"%s\" ( \"%s\" >NUL 2>NUL )\n" fname fname
+  | SH_pwsh | SH_win_powershell ->
+    Printf.sprintf "& \"%s\" > $null 2> $null\n" fname
 
 let if_interactive_script shell t e =
   let ielse else_opt = match else_opt with
     |  None -> ""
     | Some e -> Printf.sprintf "else\n  %s" e
+  in
+  let ielse_cmd else_opt = match else_opt with
+    |  None -> ""
+    | Some e -> Printf.sprintf ") else (\n  %s" e
+  in
+  let ielse_pwsh else_opt = match else_opt with
+    |  None -> ""
+    | Some e -> Printf.sprintf "} else {\n  %s" e
   in
   match shell with
   | SH_sh| SH_bash ->
@@ -526,6 +561,10 @@ let if_interactive_script shell t e =
     Printf.sprintf "if ( $?prompt ) then\n  %s%sendif\n" t @@ ielse e
   | SH_fish ->
     Printf.sprintf "if isatty\n  %s%send\n" t @@ ielse e
+  | SH_win_cmd ->
+    Printf.sprintf "echo %%cmdcmdline%% | find /i \"%%~0\" >nul\nif errorlevel 1 (\n%s%s)\n" t @@ ielse_cmd e
+  | SH_pwsh | SH_win_powershell ->
+    Printf.sprintf "if ([Environment]::UserInteractive) {\n  %s%s}\n" t @@ ielse_pwsh e
 
 let init_script root shell =
   let interactive =

--- a/src/stubs/win32/opamWin32Stubs.ml
+++ b/src/stubs/win32/opamWin32Stubs.ml
@@ -33,4 +33,5 @@ external process_putenv : int32 -> string -> string -> bool = "OPAMW_process_put
 external shGetFolderPath : int -> 'a -> string = "OPAMW_SHGetFolderPath"
 external sendMessageTimeout : nativeint -> int -> int -> 'a -> 'b -> 'c -> int * 'd = "OPAMW_SendMessageTimeout_byte" "OPAMW_SendMessageTimeout"
 external getParentProcessID : int32 -> int32 = "OPAMW_GetParentProcessID"
+external getProcessName : int32 -> string = "OPAMW_GetProcessName"
 external getConsoleAlias : string -> string -> string = "OPAMW_GetConsoleAlias"

--- a/src/stubs/win32/opamWindows.c
+++ b/src/stubs/win32/opamWindows.c
@@ -726,6 +726,23 @@ CAMLprim value OPAMW_GetParentProcessID(value processId)
   OPAMreturn(caml_copy_int32(entry.th32ParentProcessID));
 }
 
+CAMLprim value OPAMW_GetProcessName(value processId)
+{
+  CAMLparam1(processId);
+
+  PROCESSENTRY32 entry;
+  DWORD parent_pid;
+  char* msg;
+  HANDLE hProcessSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+
+  if ((msg = getProcessInfo(hProcessSnapshot, Int32_val(processId), &entry)))
+    caml_failwith(msg);
+
+  CloseHandle(hProcessSnapshot);
+
+  CAMLreturn(caml_copy_string(entry.szExeFile));
+}
+
 CAMLprim value OPAMW_GetConsoleAlias(value alias, value exeName)
 {
   CAMLparam2(alias, exeName);


### PR DESCRIPTION
- There are still some Windows systems which don't have PowerShell, but there are no systems which don't have the Command Processor, so I think it's the better "default" shell
- The escaping for the `set` command isn't quite right - the general rules for escaping in the Command Processor are - and I don't use this word lightly - insanely complicated, but luckily for the _specific_ command we're trying to use there is an easier way!