### PR TITLE
Windows shell phase 2

### DIFF
--- a/master_changes.md
+++ b/master_changes.md
@@ -302,7 +302,7 @@ users)
   * fish: fix deprecated redirection syntax `^` [#4736 @vzaliva]
   * dash: recognize dash as a POSIX shell for opam env [#4816 @jonahbeckford]
   * pwsh,powershell: use $env: for opam env [#4816 @jonahbeckford]
-  * command prompt: use SET for opam env [#4816 @jonahbeckford]
+  * command prompt: use `set` for opam env [#4816 @jonahbeckford]
 
 ## Doc
   * Standardise `macOS` use [#4782 @kit-ty-kate]

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1032,7 +1032,7 @@ let shell_opt cli validity =
     "zsh",SH_zsh;
     "fish",SH_fish;
     "pwsh",SH_pwsh;
-    "cmd",SH_win_cmd;
+    "cmd",SH_cmd;
     "powershell",SH_win_powershell
   ] |> List.map (fun (s,v) -> cli_original, s, v)
   in

--- a/src/client/opamArg.ml
+++ b/src/client/opamArg.ml
@@ -1031,9 +1031,8 @@ let shell_opt cli validity =
     "csh",SH_csh;
     "zsh",SH_zsh;
     "fish",SH_fish;
-    "pwsh",SH_pwsh;
-    "cmd",SH_cmd;
-    "powershell",SH_win_powershell
+    "pwsh",SH_pwsh None;
+    "cmd",SH_cmd
   ] |> List.map (fun (s,v) -> cli_original, s, v)
   in
   mk_enum_opt ~cli validity ["shell"] "SHELL" enum

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -359,10 +359,9 @@ let init cli =
       | Some s -> s
       | None -> OpamStd.Sys.guess_shell_compat ()
     in
-    let dot_profile = match dot_profile_o with
-      | Some n -> n
-      | None ->
-        OpamFilename.of_string (OpamStd.Sys.guess_dot_profile shell)
+    let dot_profile =
+      OpamStd.Option.Op.(dot_profile_o >>+ fun () ->
+        OpamStd.Sys.guess_dot_profile shell >>| OpamFilename.of_string)
     in
     if already_init then
       if reinit then
@@ -371,7 +370,7 @@ let init cli =
             ~no_default_config_file:no_config_file ~add_config_file:config_file
         in
         let reinit conf =
-          OpamClient.reinit ~init_config ~interactive ~dot_profile
+          OpamClient.reinit ~init_config ~interactive ?dot_profile
             ?update_config ?env_hook ?completion ~inplace ~bypass_checks
             ~check_sandbox:(not no_sandboxing)
             conf shell
@@ -394,7 +393,7 @@ let init cli =
              "Opam was already initialised. If you want to set it up again, \
               use `--interactive', `--reinit', or choose a different \
               `--root'.\n";
-         OpamEnv.setup root ~interactive ~dot_profile ?update_config ?env_hook
+         OpamEnv.setup root ~interactive ?dot_profile ?update_config ?env_hook
            ?completion ~inplace shell)
     else
     let init_config =
@@ -410,7 +409,7 @@ let init cli =
     let gt, rt, default_compiler =
       OpamClient.init
         ~init_config ~interactive
-        ?repo ~bypass_checks ~dot_profile
+        ?repo ~bypass_checks ?dot_profile
         ?update_config ?env_hook ?completion
         ~check_sandbox:(not no_sandboxing)
         shell

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1216,6 +1216,7 @@ let config cli =
       | Some s -> s
       | None -> OpamStd.Sys.guess_shell_compat ()
     in
+    let pwsh = match shell with SH_pwsh _ -> true | _ -> false in
     match command, params with
     | Some `env, [] ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
@@ -1225,8 +1226,7 @@ let config cli =
          `Ok (OpamConfigCommand.env gt sw
                 ~set_opamroot ~set_opamswitch
                 ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
-                ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
-                ~cmd:(shell=SH_cmd)
+                ~pwsh ~cmd:(shell=SH_cmd)
                 ~inplace_path))
     | Some `revert_env, [] ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
@@ -1236,8 +1236,7 @@ let config cli =
          `Ok (OpamConfigCommand.ensure_env gt sw;
               OpamConfigCommand.print_eval_env
                 ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
-                ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
-                ~cmd:(shell=SH_cmd)
+                ~pwsh ~cmd:(shell=SH_cmd)
                 (OpamEnv.add [] [])))
     | Some `list, [] ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
@@ -1526,6 +1525,7 @@ let env cli =
       | Some s -> s
       | None -> OpamStd.Sys.guess_shell_compat ()
     in
+    let pwsh = match shell with SH_pwsh _ -> true | _ -> false in
     match revert with
     | false ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
@@ -1535,14 +1535,12 @@ let env cli =
          OpamConfigCommand.env gt sw
            ~set_opamroot ~set_opamswitch
            ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
-           ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
-           ~cmd:(shell=SH_cmd)
+           ~pwsh ~cmd:(shell=SH_cmd)
            ~inplace_path);
     | true ->
       OpamConfigCommand.print_eval_env
         ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
-        ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
-        ~cmd:(shell=SH_cmd)
+        ~pwsh ~cmd:(shell=SH_cmd)
         (OpamEnv.add [] [])
   in
   let open Common_config_flags in

--- a/src/client/opamCommands.ml
+++ b/src/client/opamCommands.ml
@@ -1226,7 +1226,7 @@ let config cli =
                 ~set_opamroot ~set_opamswitch
                 ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
                 ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
-                ~cmd:(shell=SH_win_cmd)
+                ~cmd:(shell=SH_cmd)
                 ~inplace_path))
     | Some `revert_env, [] ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
@@ -1237,7 +1237,7 @@ let config cli =
               OpamConfigCommand.print_eval_env
                 ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
                 ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
-                ~cmd:(shell=SH_win_cmd)
+                ~cmd:(shell=SH_cmd)
                 (OpamEnv.add [] [])))
     | Some `list, [] ->
       OpamGlobalState.with_ `Lock_none @@ fun gt ->
@@ -1536,13 +1536,13 @@ let env cli =
            ~set_opamroot ~set_opamswitch
            ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
            ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
-           ~cmd:(shell=SH_win_cmd)
+           ~cmd:(shell=SH_cmd)
            ~inplace_path);
     | true ->
       OpamConfigCommand.print_eval_env
         ~csh:(shell=SH_csh) ~sexp ~fish:(shell=SH_fish)
         ~pwsh:(shell=SH_pwsh || shell=SH_win_powershell)
-        ~cmd:(shell=SH_win_cmd)
+        ~cmd:(shell=SH_cmd)
         (OpamEnv.add [] [])
   in
   let open Common_config_flags in

--- a/src/client/opamConfigCommand.ml
+++ b/src/client/opamConfigCommand.ml
@@ -111,9 +111,9 @@ let print_cmd_env env =
         | _ -> false
         in
         if OpamCompat.String.(exists is_special v || exists is_special k) then
-          OpamConsole.msg "SET \"%s=%s\"\n" k v
+          OpamConsole.msg "set \"%s=%s\"\n" k v
         else
-          OpamConsole.msg "SET %s=%s\n" k v
+          OpamConsole.msg "set %s=%s\n" k v
       end;
       aux r
   in

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -1039,48 +1039,42 @@ module OpamSys = struct
       Option.default unix_default_shell shell
 
   let guess_dot_profile shell =
-    let win_my_powershell f =
-      let p = Filename.concat (home ()) "Documents" in
-      if Sys.file_exists p then Filename.concat (Filename.concat p "PowerShell") f
-      else let p = Filename.concat (home ()) "My Documents" in
-      if Sys.file_exists p then Filename.concat (Filename.concat p "PowerShell") f
-      else f
-    in
     let home f =
       try Filename.concat (home ()) f
       with Not_found -> f in
     match shell with
     | SH_fish ->
-      List.fold_left Filename.concat (home ".config") ["fish"; "config.fish"]
-    | SH_zsh  -> home ".zshrc"
+      Some (List.fold_left Filename.concat (home ".config") ["fish"; "config.fish"])
+    | SH_zsh  -> Some (home ".zshrc")
     | SH_bash ->
-      (try
-         List.find Sys.file_exists [
-           (* Bash looks up these 3 files in order and only loads the first,
-              for LOGIN shells *)
-           home ".bash_profile";
-           home ".bash_login";
-           home ".profile";
-           (* Bash loads .bashrc INSTEAD, for interactive NON login shells only;
-              but it's often included from the above.
-              We may include our variables in both to be sure ; for now we rely
-              on non-login shells inheriting their env from a login shell
-              somewhere... *)
-         ]
-       with Not_found ->
-         (* iff none of the above exist, creating this should be safe *)
-         home ".bash_profile")
+      let shell =
+        (try
+           List.find Sys.file_exists [
+             (* Bash looks up these 3 files in order and only loads the first,
+                for LOGIN shells *)
+             home ".bash_profile";
+             home ".bash_login";
+             home ".profile";
+             (* Bash loads .bashrc INSTEAD, for interactive NON login shells only;
+                but it's often included from the above.
+                We may include our variables in both to be sure ; for now we rely
+                on non-login shells inheriting their env from a login shell
+                somewhere... *)
+           ]
+         with Not_found ->
+           (* iff none of the above exist, creating this should be safe *)
+           home ".bash_profile")
+      in
+      Some shell
     | SH_csh ->
       let cshrc = home ".cshrc" in
       let tcshrc = home ".tcshrc" in
-      if Sys.file_exists cshrc then cshrc else tcshrc
+      Some (if Sys.file_exists cshrc then cshrc else tcshrc)
     | SH_pwsh _ ->
-      if Sys.win32 then win_my_powershell "Microsoft.Powershell_profile.ps1" else
-      List.fold_left Filename.concat (home ".config") ["powershell"; "Microsoft.Powershell_profile.ps1"]
-    | SH_sh -> home ".profile"
+      None
+    | SH_sh -> Some (home ".profile")
     | SH_cmd ->
-      (* cmd.exe does not have a concept of profiles *)
-      home ".profile"
+      None
 
 
   let registered_at_exit = ref []

--- a/src/core/opamStd.ml
+++ b/src/core/opamStd.ml
@@ -904,9 +904,9 @@ module OpamSys = struct
     fun () -> Lazy.force os
 
   type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_pwsh
-    | SH_win_cmd | SH_win_powershell
+    | SH_cmd | SH_win_powershell
 
-  let windows_default_shell = SH_win_cmd
+  let windows_default_shell = SH_cmd
   let unix_default_shell = SH_sh
 
   let shell_of_string = function
@@ -963,7 +963,7 @@ module OpamSys = struct
     let categorize_process = function
       | "powershell.exe" | "powershell_ise.exe" -> Some (Accept SH_win_powershell)
       | "pwsh.exe" -> Some (Accept SH_pwsh)
-      | "cmd.exe" -> Some (Accept SH_win_cmd)
+      | "cmd.exe" -> Some (Accept SH_cmd)
       | "env.exe" ->
         (* If the nearest ancestor is env.exe it may be `env bash` or
            even `env cmd.exe`. On Windows we can't see whether bash,
@@ -1076,7 +1076,7 @@ module OpamSys = struct
       if Sys.win32 then win_my_powershell "Microsoft.Powershell_profile.ps1" else
       List.fold_left Filename.concat (home ".config") ["powershell"; "Microsoft.Powershell_profile.ps1"]
     | SH_sh -> home ".profile"
-    | SH_win_cmd ->
+    | SH_cmd ->
       (* cmd.exe does not have a concept of profiles *)
       home ".profile"
 

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -439,8 +439,9 @@ module Sys : sig
   val executable_name : string -> string
 
   (** The different families of shells we know about *)
-  type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_pwsh
-    | SH_cmd | SH_win_powershell
+  type powershell = Powershell_pwsh | Powershell
+  type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish
+    | SH_pwsh of powershell option | SH_cmd
 
   (** Guess the shell compat-mode *)
   val guess_shell_compat: unit -> shell

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -440,7 +440,7 @@ module Sys : sig
 
   (** The different families of shells we know about *)
   type shell = SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_pwsh
-    | SH_win_cmd | SH_win_powershell
+    | SH_cmd | SH_win_powershell
 
   (** Guess the shell compat-mode *)
   val guess_shell_compat: unit -> shell

--- a/src/core/opamStd.mli
+++ b/src/core/opamStd.mli
@@ -446,8 +446,9 @@ module Sys : sig
   (** Guess the shell compat-mode *)
   val guess_shell_compat: unit -> shell
 
-  (** Guess the location of .profile *)
-  val guess_dot_profile: shell -> string
+  (** Guess the location of .profile. Returns None if the shell doesn't
+      support the concept of a .profile file. *)
+  val guess_dot_profile: shell -> string option
 
   (** The separator character used in the PATH variable (varies depending on
       OS) *)

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -316,9 +316,10 @@ type universe = {
 type pin_kind = [ `version | OpamUrl.backend ]
 
 (** Shell compatibility modes *)
+type powershell = OpamStd.Sys.powershell = Powershell_pwsh | Powershell
 type shell = OpamStd.Sys.shell =
-    SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_pwsh
-    | SH_cmd | SH_win_powershell
+  | SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_pwsh of powershell option
+  | SH_cmd
 
 (** {2 Generic command-line definitions with filters} *)
 

--- a/src/format/opamTypes.mli
+++ b/src/format/opamTypes.mli
@@ -318,7 +318,7 @@ type pin_kind = [ `version | OpamUrl.backend ]
 (** Shell compatibility modes *)
 type shell = OpamStd.Sys.shell =
     SH_sh | SH_bash | SH_zsh | SH_csh | SH_fish | SH_pwsh
-    | SH_win_cmd | SH_win_powershell
+    | SH_cmd | SH_win_powershell
 
 (** {2 Generic command-line definitions with filters} *)
 

--- a/src/format/opamTypesBase.ml
+++ b/src/format/opamTypesBase.ml
@@ -49,7 +49,7 @@ let string_of_shell = function
   | SH_sh   -> "sh"
   | SH_bash -> "bash"
   | SH_pwsh -> "pwsh"
-  | SH_win_cmd -> "cmd"
+  | SH_cmd -> "cmd"
   | SH_win_powershell -> "powershell"
 
 let file_null = ""

--- a/src/format/opamTypesBase.ml
+++ b/src/format/opamTypesBase.ml
@@ -43,14 +43,13 @@ let all_std_paths =
   [ Prefix; Lib; Bin; Sbin; Share; Doc; Etc; Man; Toplevel; Stublibs ]
 
 let string_of_shell = function
-  | SH_fish -> "fish"
-  | SH_csh  -> "csh"
-  | SH_zsh  -> "zsh"
-  | SH_sh   -> "sh"
-  | SH_bash -> "bash"
-  | SH_pwsh -> "pwsh"
-  | SH_cmd -> "cmd"
-  | SH_win_powershell -> "powershell"
+  | SH_fish   -> "fish"
+  | SH_csh    -> "csh"
+  | SH_zsh    -> "zsh"
+  | SH_sh     -> "sh"
+  | SH_bash   -> "bash"
+  | SH_pwsh _ -> "pwsh"
+  | SH_cmd    -> "cmd"
 
 let file_null = ""
 let pos_file filename =

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -365,7 +365,7 @@ let is_up_to_date ?skip st =
 (** Returns shell-appropriate statement to evaluate [cmd]. *)
 let shell_eval_invocation shell cmd =
   match shell with
-  | SH_win_powershell | SH_pwsh ->
+  | SH_pwsh _ ->
     Printf.sprintf "(& %s) -split '\\r?\\n' | ForEach-Object { Invoke-Expression $_ }" cmd
   | SH_fish ->
     Printf.sprintf "eval (%s)" cmd
@@ -427,21 +427,21 @@ let shells_list = [ SH_sh; SH_zsh; SH_csh; SH_fish ]
 let complete_file = function
   | SH_sh | SH_bash -> Some "complete.sh"
   | SH_zsh -> Some "complete.zsh"
-  | SH_csh | SH_fish | SH_pwsh | SH_cmd | SH_win_powershell -> None
+  | SH_csh | SH_fish | SH_pwsh _ | SH_cmd -> None
 
 let env_hook_file = function
   | SH_sh | SH_bash -> Some "env_hook.sh"
   | SH_zsh -> Some "env_hook.zsh"
   | SH_csh -> Some "env_hook.csh"
   | SH_fish -> Some "env_hook.fish"
-  | SH_pwsh | SH_cmd | SH_win_powershell ->
+  | SH_pwsh _ | SH_cmd ->
     (* N/A because not present in `shells_list` yet *) None
 
 let variables_file = function
   | SH_sh | SH_bash | SH_zsh -> "variables.sh"
   | SH_csh -> "variables.csh"
   | SH_fish -> "variables.fish"
-  | SH_pwsh | SH_cmd | SH_win_powershell ->
+  | SH_pwsh _ | SH_cmd ->
     (* N/A because not present in `shells_list` yet *) "variables.sh"
 
 let init_file = function
@@ -449,21 +449,21 @@ let init_file = function
   | SH_zsh -> "init.zsh"
   | SH_csh -> "init.csh"
   | SH_fish -> "init.fish"
-  | SH_pwsh | SH_cmd | SH_win_powershell ->
+  | SH_pwsh _ | SH_cmd ->
     (* N/A because not present in `shells_list` yet *) "init.sh"
 
 let complete_script = function
   | SH_sh | SH_bash -> Some OpamScript.complete
   | SH_zsh -> Some OpamScript.complete_zsh
   | SH_csh | SH_fish -> None
-  | SH_pwsh | SH_cmd | SH_win_powershell -> None
+  | SH_pwsh _ | SH_cmd -> None
 
 let env_hook_script_base = function
   | SH_sh | SH_bash -> Some OpamScript.env_hook
   | SH_zsh -> Some OpamScript.env_hook_zsh
   | SH_csh -> Some OpamScript.env_hook_csh
   | SH_fish -> Some OpamScript.env_hook_fish
-  | SH_pwsh | SH_cmd | SH_win_powershell -> None
+  | SH_pwsh _ | SH_cmd -> None
 
 let export_in_shell shell =
   let make_comment comment_opt =
@@ -512,7 +512,7 @@ let export_in_shell shell =
   | SH_zsh | SH_bash | SH_sh -> sh
   | SH_fish -> fish
   | SH_csh -> csh
-  | SH_pwsh | SH_win_powershell -> pwsh
+  | SH_pwsh _ -> pwsh
   | SH_cmd -> cmd
 
 let env_hook_script shell =
@@ -536,7 +536,7 @@ let source root shell f =
       fname fname
   | SH_cmd ->
     Printf.sprintf "if exist \"%s\" ( \"%s\" >NUL 2>NUL )\n" fname fname
-  | SH_pwsh | SH_win_powershell ->
+  | SH_pwsh _ ->
     Printf.sprintf "& \"%s\" > $null 2> $null\n" fname
 
 let if_interactive_script shell t e =
@@ -563,7 +563,7 @@ let if_interactive_script shell t e =
     Printf.sprintf "if isatty\n  %s%send\n" t @@ ielse e
   | SH_cmd ->
     Printf.sprintf "echo %%cmdcmdline%% | find /i \"%%~0\" >nul\nif errorlevel 1 (\n%s%s)\n" t @@ ielse_cmd e
-  | SH_pwsh | SH_win_powershell ->
+  | SH_pwsh _ ->
     Printf.sprintf "if ([Environment]::UserInteractive) {\n  %s%s}\n" t @@ ielse_pwsh e
 
 let init_script root shell =

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -371,7 +371,7 @@ let shell_eval_invocation shell cmd =
     Printf.sprintf "eval (%s)" cmd
   | SH_csh ->
     Printf.sprintf "eval `%s`" cmd
-  | SH_win_cmd ->
+  | SH_cmd ->
     Printf.sprintf {|for /f "tokens=*" %%i in ('%s') do @%%i|} cmd
   | _ ->
     Printf.sprintf "eval $(%s)" cmd
@@ -427,21 +427,21 @@ let shells_list = [ SH_sh; SH_zsh; SH_csh; SH_fish ]
 let complete_file = function
   | SH_sh | SH_bash -> Some "complete.sh"
   | SH_zsh -> Some "complete.zsh"
-  | SH_csh | SH_fish | SH_pwsh | SH_win_cmd | SH_win_powershell -> None
+  | SH_csh | SH_fish | SH_pwsh | SH_cmd | SH_win_powershell -> None
 
 let env_hook_file = function
   | SH_sh | SH_bash -> Some "env_hook.sh"
   | SH_zsh -> Some "env_hook.zsh"
   | SH_csh -> Some "env_hook.csh"
   | SH_fish -> Some "env_hook.fish"
-  | SH_pwsh | SH_win_cmd | SH_win_powershell ->
+  | SH_pwsh | SH_cmd | SH_win_powershell ->
     (* N/A because not present in `shells_list` yet *) None
 
 let variables_file = function
   | SH_sh | SH_bash | SH_zsh -> "variables.sh"
   | SH_csh -> "variables.csh"
   | SH_fish -> "variables.fish"
-  | SH_pwsh | SH_win_cmd | SH_win_powershell ->
+  | SH_pwsh | SH_cmd | SH_win_powershell ->
     (* N/A because not present in `shells_list` yet *) "variables.sh"
 
 let init_file = function
@@ -449,21 +449,21 @@ let init_file = function
   | SH_zsh -> "init.zsh"
   | SH_csh -> "init.csh"
   | SH_fish -> "init.fish"
-  | SH_pwsh | SH_win_cmd | SH_win_powershell ->
+  | SH_pwsh | SH_cmd | SH_win_powershell ->
     (* N/A because not present in `shells_list` yet *) "init.sh"
 
 let complete_script = function
   | SH_sh | SH_bash -> Some OpamScript.complete
   | SH_zsh -> Some OpamScript.complete_zsh
   | SH_csh | SH_fish -> None
-  | SH_pwsh | SH_win_cmd | SH_win_powershell -> None
+  | SH_pwsh | SH_cmd | SH_win_powershell -> None
 
 let env_hook_script_base = function
   | SH_sh | SH_bash -> Some OpamScript.env_hook
   | SH_zsh -> Some OpamScript.env_hook_zsh
   | SH_csh -> Some OpamScript.env_hook_csh
   | SH_fish -> Some OpamScript.env_hook_fish
-  | SH_pwsh | SH_win_cmd | SH_win_powershell -> None
+  | SH_pwsh | SH_cmd | SH_win_powershell -> None
 
 let export_in_shell shell =
   let make_comment comment_opt =
@@ -502,7 +502,7 @@ let export_in_shell shell =
   let pwsh (k,v,comment) =
     Printf.sprintf "%s$env:%s=%s;\n"
       (make_comment comment) k v in
-  let win_cmd (k,v,comment) =
+  let cmd (k,v,comment) =
     let make_cmd_comment comment_opt =
       OpamStd.Option.to_string (Printf.sprintf "REM %s\n") comment_opt
     in
@@ -513,7 +513,7 @@ let export_in_shell shell =
   | SH_fish -> fish
   | SH_csh -> csh
   | SH_pwsh | SH_win_powershell -> pwsh
-  | SH_win_cmd -> win_cmd
+  | SH_cmd -> cmd
 
 let env_hook_script shell =
   OpamStd.Option.map (fun script ->
@@ -534,7 +534,7 @@ let source root shell f =
   | SH_zsh ->
     Printf.sprintf "[[ ! -r %s ]] || source %s  > /dev/null 2> /dev/null\n"
       fname fname
-  | SH_win_cmd ->
+  | SH_cmd ->
     Printf.sprintf "if exist \"%s\" ( \"%s\" >NUL 2>NUL )\n" fname fname
   | SH_pwsh | SH_win_powershell ->
     Printf.sprintf "& \"%s\" > $null 2> $null\n" fname
@@ -561,7 +561,7 @@ let if_interactive_script shell t e =
     Printf.sprintf "if ( $?prompt ) then\n  %s%sendif\n" t @@ ielse e
   | SH_fish ->
     Printf.sprintf "if isatty\n  %s%send\n" t @@ ielse e
-  | SH_win_cmd ->
+  | SH_cmd ->
     Printf.sprintf "echo %%cmdcmdline%% | find /i \"%%~0\" >nul\nif errorlevel 1 (\n%s%s)\n" t @@ ielse_cmd e
   | SH_pwsh | SH_win_powershell ->
     Printf.sprintf "if ([Environment]::UserInteractive) {\n  %s%s}\n" t @@ ielse_pwsh e

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -506,7 +506,7 @@ let export_in_shell shell =
     let make_cmd_comment comment_opt =
       OpamStd.Option.to_string (Printf.sprintf "REM %s\n") comment_opt
     in
-    Printf.sprintf "%sSET \"%s=%s\"\n"
+    Printf.sprintf "%sset \"%s=%s\"\n"
       (make_cmd_comment comment) k v in
   match shell with
   | SH_zsh | SH_bash | SH_sh -> sh

--- a/src/state/opamEnv.ml
+++ b/src/state/opamEnv.ml
@@ -504,7 +504,7 @@ let export_in_shell shell =
       (make_comment comment) k v in
   let cmd (k,v,comment) =
     let make_cmd_comment comment_opt =
-      OpamStd.Option.to_string (Printf.sprintf "REM %s\n") comment_opt
+      OpamStd.Option.to_string (Printf.sprintf ":: %s\n") comment_opt
     in
     Printf.sprintf "%sset \"%s=%s\"\n"
       (make_cmd_comment comment) k v in


### PR DESCRIPTION
- The use of `win_cmd` is a bit verbose in the code - the shell is _called_ `cmd` so rename the constructor
- PowerShell has a concept of "host". It's a slightly crazy name because it refers to the interpreter, not the computer - so `pwsh` (modern PowerShell), `powershell` (classic PowerShell) and PowerShellISE (the GUI version) can all be configured separately. I don't think it's sensible to have separate constructors for them - the information on the exact host is kept as a value in the variant instead (although we don't actually do anything with at the moment, so maybe it could be removed completely)
- I prefer `set` to `SET` and `::` to `rem` in Command Processor scripts
- We're generating an invalid `.profile` file for the Command Processor and an invalid PowerShell equivalent - I'll have follow-up work for PowerShell, but in the cmd case, this changes the `opam init` process to be able to cope with shells which don't support the concept of `.profile`